### PR TITLE
Increased allowed invalid locations to 1000.

### DIFF
--- a/web/handelsregister/datasets/hr/improve_location_with_search.py
+++ b/web/handelsregister/datasets/hr/improve_location_with_search.py
@@ -1023,7 +1023,7 @@ def guess():
 
         # check if we did a good job doing corrections.
         # normally about ~60 invalid locations left of 10.000
-        assert invalid_locations.count() < 800
+        assert invalid_locations.count() < 1000
 
     status_job.kill()
 


### PR DESCRIPTION
As requested by Service Delivery, the number of allowed invalid locations has been increased from 800 to 1000.