### PR TITLE
#AD37958 fix auth issues and add deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Handelsregister API
 =====================
 
+**Deprecated** This repo is no longer actively maintained. All stakeholders should migrate to dso-api 
+as soon as possible. This is repo is kept only to support legacy users.
+
 Handelsregister (HR)
 
 Serve a stelselpedia API of Handelsregister items

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,6 +3,8 @@ swagger: '2.0'
 info:
   title: Handelsregister API
   description: |
+        Waarschuwing! Deze API wordt niet meer actief ondersteund. Alles gebruikers 
+        zouden zo snel mogelijk moeten overstappen op de nieuwe api op api.data.amsterdam.nl/v1/
         Door datapunt verrijkte dataset van het Handelsregister. (HR)
         Venieuwing is wekelijks. 10% van adressen in het Handelsregister
         zijn geen BAG adressen. Dit hebben wij bij datapunt zo goed mogelijk

--- a/web/handelsregister/handelsregister/settings.py
+++ b/web/handelsregister/handelsregister/settings.py
@@ -261,7 +261,7 @@ SWAGGER_SETTINGS = {
     'SECURITY_DEFINITIONS': {
         'oauth2': {
             'type': 'oauth2',
-            'authorizationUrl': DATAPUNT_API_URL + "oauth2/authorize",
+            'authorizationUrl': "https://iam.amsterdam.nl/auth/realms/datapunt-ad/protocol/openid-connect/auth",
             'flow': 'implicit',
             'scopes': {
                 SCOPE_HR_R: "Toegang HR",


### PR DESCRIPTION
Authorization in swagger didnt work anymore because the authorization server no longer exists.
The swagger auth url was updated to the new iam server.

Deprecation messages were added to the README and swagger page.
