### PR TITLE
Bump Django to 2.2.28

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -12,7 +12,7 @@ cryptography==3.3.2
 datapunt-authorization-django==1.3.2
 debtcollector==1.20.0
 defusedxml==0.6.0
-Django==2.2.27
+Django==2.2.28
 django-braces==1.13.0
 django-cors-headers==2.4.0
 django-debug-toolbar==1.11.1


### PR DESCRIPTION
Bump Django because of CVE-2022-28346