### PR TITLE
Use less workers to prevent 429 bag api

### DIFF
--- a/web/handelsregister/datasets/hr/improve_location_with_search.py
+++ b/web/handelsregister/datasets/hr/improve_location_with_search.py
@@ -59,7 +59,7 @@ P6LEVEL = 1000
 
 # the amount of concurrent workers that do requests
 # to the search api
-WORKERS = 10
+WORKERS = 7
 
 if SLOW:
     WORKERS = 1  # 25


### PR DESCRIPTION
error logs:
datasets.hr.improve_location_with_search - ERROR - (0) RESPONSE 429, https://acc.api.data.amsterdam.nl/atlas/search/adres/?q=keizersgracht+62+