### PR TITLE
Disable `X-Api-Key` header for location search

### DIFF
--- a/web/handelsregister/datasets/hr/improve_location_with_search.py
+++ b/web/handelsregister/datasets/hr/improve_location_with_search.py
@@ -251,7 +251,10 @@ def is_straat_huisnummer(tokens) -> int:
 class SearchTask:
     """All data relevant for async search instance."""
 
-    HEADER = {'X-Api-Key': settings.DATAPUNT_API_REQUEST_HEADER}
+    # {'X-Api-Key': settings.DATAPUNT_API_REQUEST_HEADER}
+    # Temp disable X-Api-Key until there is a valid key for this repo
+
+    HEADER = {}
     RETRIES = 1 if settings.TESTING else 5
 
     def __init__(self, locatieobject, query_string, straatnaam,


### PR DESCRIPTION
Until a valid key is set, disable for now